### PR TITLE
Fix issues; Update scripts to use `iob_module` instances instead of the old `iob_verilog_instance` class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The main class that describes this core is located in the `iob_pfsm.py` Python m
 The following steps describe the process of creating a PFSM peripheral in an IOb-SoC-based system:
 1) Import the `iob_pfsm` class
 2) Run the `iob_pfsm.setup()` method to copy the required sources of this module to the build directory.
-3) Run the `iob_pfsm.instance(...)` method to create a Verilog instance of the PFSM peripheral.
+3) Run the `iob_pfsm(...)` method to create a Verilog instance of the PFSM peripheral.
 To use this core as a peripheral of an IOb-SoC-based system:
   4) Add the created instance to the peripherals list of the IOb-SoC-based system.
   5) Write the firmware to run in the system, including the `iob-pfsm.h` C header and use its driver functions to control this core.
@@ -51,7 +51,7 @@ class iob_soc_tester(iob_soc):
     ...
     # Create a Verilog instance of this module, named 'PFSM0', and add it to the peripherals list of the system.
     cls.peripherals.append(
-        iob_pfsm.instance(
+        iob_pfsm(
             "PFSM0",
             "PFSM interface",
             parameters={"STATE_W": "2", "INPUT_W": "1", "OUTPUT_W": "1"},

--- a/hardware/src/iob_pfsm.v
+++ b/hardware/src/iob_pfsm.v
@@ -7,70 +7,66 @@
 `define IOB_PFSM_CEIL_DIV(A, B) (A % B == 0 ? (A / B) : ((A/B) + 1))
 
 module iob_pfsm # (
-     `include "iob_pfsm_params.vs"
-   ) (
-     `include "iob_pfsm_io.vs"
-    );
-    // This mapping is required because "iob_pfsm_swreg_inst.vs" uses "iob_s_portmap.vs" (This would not be needed if mkregs used "iob_s_s_portmap.vs" instead)
-    wire [1-1:0] iob_avalid = iob_avalid_i; //Request valid.
-    wire [ADDR_W-1:0] iob_addr = iob_addr_i; //Address.
-    wire [DATA_W-1:0] iob_wdata = iob_wdata_i; //Write data.
-    wire [(DATA_W/8)-1:0] iob_wstrb = iob_wstrb_i; //Write strobe.
-    wire [1-1:0] iob_rvalid; assign iob_rvalid_o = iob_rvalid; //Read data valid.
-    wire [DATA_W-1:0] iob_rdata; assign iob_rdata_o = iob_rdata; //Read data.
-    wire [1-1:0] iob_ready; assign iob_ready_o = iob_ready; //Interface ready.
+   `include "iob_pfsm_params.vs"
+  ) (
+   `include "iob_pfsm_io.vs"
+  );
 
-    //BLOCK Register File & Configuration control and status register file.
-    `include "iob_pfsm_swreg_inst.vs"
+   //Dummy iob_ready_nxt_o and iob_rvalid_nxt_o to be used in swreg (unused ports)
+   wire iob_ready_nxt_o;
+   wire iob_rvalid_nxt_o;
 
-    // Keep track of current PFSM state
-    wire [STATE_W-1:0] next_state, current_state;
-    iob_reg_r #(
-      .DATA_W (STATE_W),
-      .RST_VAL(1'b0)
-    ) state_reg (
-      .clk_i(clk_i),
-      .cke_i(cke_i),
-      .arst_i(arst_i),
-      .rst_i(SOFTRESET),
-      .data_i(next_state),
-      .data_o(current_state)
-    );
+  //BLOCK Register File & Configuration control and status register file.
+  `include "iob_pfsm_swreg_inst.vs"
 
-    assign CURRENT_STATE = current_state;
+  // Keep track of current PFSM state
+  wire [STATE_W-1:0] next_state, current_state;
+  iob_reg_r #(
+    .DATA_W (STATE_W),
+    .RST_VAL(1'b0)
+  ) state_reg (
+    .clk_i(clk_i),
+    .cke_i(cke_i),
+    .arst_i(arst_i),
+    .rst_i(SOFTRESET),
+    .data_i(next_state),
+    .data_o(current_state)
+  );
 
-    // Number of bytes in IOb-Native data bus
-    localparam N_BYTES_DATA_WORD = `IOB_PFSM_CEIL_DIV(DATA_W,8);
-    // Number of bytes in each LUT memory word
-    localparam LUT_DATA_W = STATE_W+OUTPUT_W;
-    // Number of bits to shift for word select
-    localparam WORD_SELECT_SHIFT = N_BYTES_DATA_WORD*MEM_WORD_SELECT;
+  assign CURRENT_STATE = current_state;
 
-    wire [LUT_DATA_W-1:0] lut_o;
-    // LUT data input signal. Composed of same bits as currently in LUT joined by new DATA_W bits.
-    wire [LUT_DATA_W-1:0] lut_data_input = lut_o[LUT_DATA_W-1:WORD_SELECT_SHIFT+DATA_W] | iob_wdata<<(WORD_SELECT_SHIFT) | lut_o[0+:WORD_SELECT_SHIFT];
-    // LUT address. Either memory address corresponding to:
-    //  1) curent_state, input_combination
-    //  2) Selected memory address for writing
-    wire [INPUT_W+STATE_W-1:0] lut_addr = MEMORY_wen ? (iob_addr-`IOB_PFSM_MEMORY_ADDR)>>$clog2(N_BYTES_DATA_WORD) : {current_state,input_ports};
+  // Number of bytes in IOb-Native data bus
+  localparam N_BYTES_DATA_WORD = `IOB_PFSM_CEIL_DIV(DATA_W,8);
+  // Number of bytes in each LUT memory word
+  localparam LUT_DATA_W = STATE_W+OUTPUT_W;
+  // Number of bits to shift for word select
+  localparam WORD_SELECT_SHIFT = N_BYTES_DATA_WORD*MEM_WORD_SELECT;
 
-   // Memory used as LUT for PFSM states
-   iob_regfile_sp #(
-      .DATA_W(STATE_W+OUTPUT_W),
-      .ADDR_W(INPUT_W+STATE_W)
-   ) lut (
-      .clk_i(clk_i),
-      .cke_i(cke_i),
-      .arst_i(arst_i),
-      .rst_i(1'b0),
-      .we_i(MEMORY_wen),
-      .addr_i(lut_addr),
-      .d_i(lut_data_input),
-      .d_o(lut_o)
-   );
-   
-   // Extract bits from word of `lut_o`
-   assign output_ports = lut_o[0+:OUTPUT_W]; // Least significant bits connected to output
-   assign next_state = lut_o[OUTPUT_W+:STATE_W]; // Followed by next_state bits
+  wire [LUT_DATA_W-1:0] lut_o;
+  // LUT data input signal. Composed of same bits as currently in LUT joined by new DATA_W bits.
+  wire [LUT_DATA_W-1:0] lut_data_input = lut_o[LUT_DATA_W-1:WORD_SELECT_SHIFT+DATA_W] | iob_wdata_i<<(WORD_SELECT_SHIFT) | lut_o[0+:WORD_SELECT_SHIFT];
+  // LUT address. Either memory address corresponding to:
+  //  1) curent_state, input_combination
+  //  2) Selected memory address for writing
+  wire [INPUT_W+STATE_W-1:0] lut_addr = MEMORY_wen ? (iob_addr_i-`IOB_PFSM_MEMORY_ADDR)>>$clog2(N_BYTES_DATA_WORD) : {current_state,input_ports};
+
+ // Memory used as LUT for PFSM states
+ iob_regfile_sp #(
+    .DATA_W(STATE_W+OUTPUT_W),
+    .ADDR_W(INPUT_W+STATE_W)
+ ) lut (
+    .clk_i(clk_i),
+    .cke_i(cke_i),
+    .arst_i(arst_i),
+    .rst_i(1'b0),
+    .we_i(MEMORY_wen),
+    .addr_i(lut_addr),
+    .d_i(lut_data_input),
+    .d_o(lut_o)
+ );
+
+ // Extract bits from word of `lut_o`
+ assign output_ports = lut_o[0+:OUTPUT_W]; // Least significant bits connected to output
+ assign next_state = lut_o[OUTPUT_W+:STATE_W]; // Followed by next_state bits
 
 endmodule

--- a/iob_pfsm.py
+++ b/iob_pfsm.py
@@ -21,8 +21,8 @@ class iob_pfsm(iob_module):
         ''' Create submodules list with dependencies of this module
         '''
         super()._create_submodules_list([
-            "iob_s_port",
-            "iob_s_portmap",
+            {"interface": "iob_s_port"},
+            {"interface": "iob_s_portmap"},
             iob_reg,
             iob_reg_e,
         ])


### PR DESCRIPTION
- Fix word select logic.
- Update interface dictionary for generation..
- Update scripts to use `iob_module` instances instead of the old `iob_verilog_instance` class, according to changes in PR https://github.com/IObundle/iob-lib/pull/625